### PR TITLE
Change hook call to reflect 7.x deprecation.

### DIFF
--- a/Classes/Hooks/class.tx_jhmagnificpopup_tcemain.php
+++ b/Classes/Hooks/class.tx_jhmagnificpopup_tcemain.php
@@ -42,10 +42,10 @@ class tx_jhmagnificpopup_tcemain {
 	 * @param array $incomingFieldArray
 	 * @param string $table
 	 * @param integer $id
-	 * @param t3lib_TCEmain $pObj
+	 * @param TYPO3\CMS\Core\DataHandling\DataHandler $pObj
 	 * @see tx_templavoila_tcemain::processDatamap_afterDatabaseOperations()
 	 */
-	public function processDatamap_preProcessFieldArray(array &$incomingFieldArray, $table, $id, t3lib_TCEmain &$pObj) {
+	public function processDatamap_preProcessFieldArray(array &$incomingFieldArray, $table, $id, TYPO3\CMS\Core\DataHandling\DataHandler &$pObj) {
 		if ($incomingFieldArray['list_type'] != 'jhmagnificpopup_pi1') {
 			if (is_array($pObj->datamap['tt_content'])) {
 				foreach ($pObj->datamap['tt_content'] as $key => $val) {


### PR DESCRIPTION
Had to make it work with TYPO3 CMS 7.4 and changing the hook's call made it work. Change is tested with 0.4.1 only, but should be a no-brainer.
