### PR TITLE
TASK: Do not load RTE configuration by default

### DIFF
--- a/Configuration/TCA/Overrides/pages.php
+++ b/Configuration/TCA/Overrides/pages.php
@@ -1,0 +1,13 @@
+<?php
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
+	'jh_magnificpopup',
+	'Configuration/TsConfig/Page/Links/PageTsConfig.txt',
+	'Magnific Popup : Load RTE link classes (rtehtmlarea)'
+);
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::registerPageTSConfigFile(
+	'jh_magnificpopup',
+	'Configuration/TsConfig/Page/AlphaFeatures/PageTsConfig.txt',
+	'Magnific Popup : Alpha Features :: May change in the future, not for production usage'
+);

--- a/Configuration/TsConfig/Page/AlphaFeatures/PageTsConfig.txt
+++ b/Configuration/TsConfig/Page/AlphaFeatures/PageTsConfig.txt
@@ -1,0 +1,13 @@
+RTE.classesAnchor {
+	internalCEInMagnificpopup {
+		class = mfp-content-element internal-link-new-window
+		type = page
+		image >
+		titleText = LLL:EXT:jh_magnificpopup/Resources/Private/Language/locallang.xlf:pageTSconfig.internalCEInMagnificpopup
+	}
+}
+
+RTE.default.proc.allowedClasses := addToList(mfp-content-element internal-link-new-window)
+RTE.default.classesAnchor := addToList(mfp-content-element internal-link-new-window)
+
+RTE.default.buttons.link.properties.class.allowedClasses := addToList(mfp-content-element internal-link-new-window)

--- a/Configuration/TsConfig/Page/Links/PageTsConfig.txt
+++ b/Configuration/TsConfig/Page/Links/PageTsConfig.txt
@@ -1,0 +1,25 @@
+RTE.classesAnchor {
+	externalLinkInMagnificpopup {
+		class = mfp-link external-link-new-window
+		type = url
+		image >
+		titleText = LLL:EXT:jh_magnificpopup/Resources/Private/Language/locallang.xlf:pageTSconfig.externalLinkInMagnificpopup
+	}
+	internalLinkInMagnificpopup {
+		class = mfp-link internal-link-new-window
+		type = page
+		image >
+		titleText = LLL:EXT:jh_magnificpopup/Resources/Private/Language/locallang.xlf:pageTSconfig.internalLinkInMagnificpopup
+	}
+	downloadInMagnificpopup {
+		class = mfp-link download
+		type = file
+		image >
+		titleText = LLL:EXT:jh_magnificpopup/Resources/Private/Language/locallang.xlf:pageTSconfig.downloadInMagnificpopup
+	}
+}
+
+RTE.default.proc.allowedClasses := addToList(mfp-link external-link-new-window, mfp-link internal-link-new-window, mfp-link download)
+RTE.default.classesAnchor := addToList(mfp-link external-link-new-window, mfp-link internal-link-new-window, mfp-link download)
+
+RTE.default.buttons.link.properties.class.allowedClasses := addToList(mfp-link external-link-new-window, mfp-link internal-link-new-window, mfp-link download)

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,5 +1,2 @@
 # cat=basic/enable/100; type=integer; label=colPos of IRRE Content: Select the colPos where the tt_content will be saved in IRRE-view
 colPosOfIrreContent = 109
-
-# cat=basic/enable/200; type=boolean; label=Enable alpha features: Please note that alpha features may change, not for productive usage!
-enableAlphaFeatures = 0

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -36,57 +36,7 @@ $iconRegistry->registerIcon(
             list_type = jhmagnificpopup_pi1
         }
     }
-
-
-	RTE.classesAnchor {
-	  externalLinkInMagnificpopup {
-	    class = mfp-link external-link-new-window
-	    type = url
-	    image >
-	    titleText = LLL:EXT:jh_magnificpopup/Resources/Private/Language/locallang.xlf:pageTSconfig.externalLinkInMagnificpopup
-	  }
-	  internalLinkInMagnificpopup {
-	    class = mfp-link internal-link-new-window
-	    type = page
-	    image >
-	    titleText = LLL:EXT:jh_magnificpopup/Resources/Private/Language/locallang.xlf:pageTSconfig.internalLinkInMagnificpopup
-	  }
-	  downloadInMagnificpopup {
-	    class = mfp-link download
-	    type = file
-	    image >
-	    titleText = LLL:EXT:jh_magnificpopup/Resources/Private/Language/locallang.xlf:pageTSconfig.downloadInMagnificpopup
-	  }
-	}
-
-	RTE.default.proc.allowedClasses := addToList(mfp-link external-link-new-window, mfp-link internal-link-new-window, mfp-link download)
-	RTE.default.classesAnchor := addToList(mfp-link external-link-new-window, mfp-link internal-link-new-window, mfp-link download)
-
-	RTE.default.buttons.link.properties.class.allowedClasses := addToList(mfp-link external-link-new-window, mfp-link internal-link-new-window, mfp-link download)
 ');
 
 // Add eID for ajax-content
 $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['jh_magnificpopup_ajax'] = 'EXT:'.$_EXTKEY.'/Resources/Public/Php/EidRunner.php';
-
-
-//
-// alpha-features::
-//
-$extConfig = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['jh_magnificpopup']);
-if (isset($extConfig['enableAlphaFeatures']) && $extConfig['enableAlphaFeatures'] == 1) {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('
-		RTE.classesAnchor {
-		  internalCEInMagnificpopup {
-		    class = mfp-content-element internal-link-new-window
-		    type = page
-		    image >
-		    titleText = LLL:EXT:jh_magnificpopup/Resources/Private/Language/locallang.xlf:pageTSconfig.internalCEInMagnificpopup
-		  }
-		}
-
-		RTE.default.proc.allowedClasses := addToList(mfp-content-element internal-link-new-window)
-		RTE.default.classesAnchor := addToList(mfp-content-element internal-link-new-window)
-
-		RTE.default.buttons.link.properties.class.allowedClasses := addToList(mfp-content-element internal-link-new-window)
-	');
-}


### PR DESCRIPTION
They are now loadable via page tsconfig preset and which does not break ckeditor configuration

Relates: #47