### PR TITLE
close button hardly or not clickable

### DIFF
--- a/Resources/Public/js/jquery.magnific-popup.js
+++ b/Resources/Public/js/jquery.magnific-popup.js
@@ -724,7 +724,7 @@ MagnificPopup.prototype = {
 		} else {
 
 			// We close the popup if click is on close button or on preloader. Or if there is no content.
-			if(!mfp.content || $(target).hasClass('mfp-close') || (mfp.preloader && target === mfp.preloader[0]) ) {
+			if(!mfp.content || $(target).closest('.mfp-close').length || (mfp.preloader && target === mfp.preloader[0]) ) {
 				return true;
 			}
 


### PR DESCRIPTION
for closeOnContentClick = 0 the .mfp-close-icn cannot be clicked. Only the unlying button element is clickable. If you increase the icon size, the button will not be clickable at all. Minified version of JS lib is still missing.