### PR TITLE
[TASK] Support TYPO3 9 LTS (Related to #62) -- TS Conditions

### DIFF
--- a/Configuration/TypoScript/Default/setup.txt
+++ b/Configuration/TypoScript/Default/setup.txt
@@ -37,7 +37,7 @@ page.includeJSFooterlibs {
 }
 
 # Config tx_news if support is set
-[globalVar = LIT:1 = {$plugin.tx_jhmagnificpopup.magnificpopup.support.tx_news}]
+["1" == "{$plugin.tx_jhmagnificpopup.magnificpopup.support.tx_news}"]
     plugin.tx_news.settings.detail.media.image {
         lightbox = magnificpopup
     }

--- a/Configuration/TypoScript/Inline/setup.txt
+++ b/Configuration/TypoScript/Inline/setup.txt
@@ -151,7 +151,7 @@ plugin.tx_jhmagnificpopup.settings {
 }
 
 // Include javascript of iframe if enabled global
-[globalVar = LIT:1 = {$plugin.tx_jhmagnificpopup.type.iframe.enableglobal}]
+["1" == "{$plugin.tx_jhmagnificpopup.type.iframe.enableglobal}"]
     plugin.tx_jhmagnificpopup.settings.type.iframe {
         # Copy actual page.jsFooterInline to setup to prevent from data-loss
         setup < page.jsFooterInline
@@ -168,7 +168,7 @@ plugin.tx_jhmagnificpopup.settings {
 [global]
 
 // Include javascript of ajax if enabled global
-[globalVar = LIT:1 = {$plugin.tx_jhmagnificpopup.type.ajax.enableglobal}]
+["1" == "{$plugin.tx_jhmagnificpopup.type.ajax.enableglobal}"]
     plugin.tx_jhmagnificpopup.settings.type.ajax {
         # Copy actual page.jsFooterInline to setup to prevent from data-loss
         setup < page.jsFooterInline
@@ -201,7 +201,7 @@ ajaxcontent {
 }
 
 // Render inline-content
-[globalString = GP:jh_magnificpopup|type=inline]
+[request.getQueryParams()['jh_magnificpopup']['type'] == 'inline']
     ajaxcontent.10 {
         10 >
         10 = CONTENT
@@ -219,7 +219,7 @@ ajaxcontent {
 [global]
 
 // Render from reference to content-element
-[globalString = GP:jh_magnificpopup|type=reference]
+[request.getQueryParams()['jh_magnificpopup']['type'] == 'reference']
     ajaxcontent.10 {
         10 >
         10 = CONTENT
@@ -257,7 +257,7 @@ plugin.tx_jhmagnificpopup._CSS_DEFAULT_STYLE (
 
 
 // Include javascript of inlineCE if enabled
-[globalVar = LIT:1 = {$plugin.tx_jhmagnificpopup.enableAlphaFeatures}]
+["1" == "{$plugin.tx_jhmagnificpopup.enableAlphaFeatures}"]
     plugin.tx_jhmagnificpopup.settings.type.iframe {
         # Copy actual page.jsFooterInline to setup to prevent from data-loss
         setup < page.jsFooterInline

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -26,7 +26,7 @@ $EM_CONF[$_EXTKEY] = array (
   array (
     'depends' => 
     array (
-      'typo3' => '8.7.0-9.5.99',
+      'typo3' => '9.5.0-9.5.99',
     ),
     'conflicts' => 
     array (


### PR DESCRIPTION
In TYPO3 9 the old condition syntax is technically allowed but throws a lot of warnings into the log if `[SYS][features][TypoScript.strictSyntax]` is enabled (which it is by default)